### PR TITLE
Fixed broken programmes test

### DIFF
--- a/application/tests/controllers/programmes.test.php
+++ b/application/tests/controllers/programmes.test.php
@@ -8,7 +8,6 @@ class TestProgrammes_Controller extends ControllerTestCase
 	{
 		// Setup something we can edit.
 		$input = array(
-			'id' => 1,
 			'year' => '2012',
 			'live' => '1',
 			'created_by' => 'aa',


### PR DESCRIPTION
Aaaargh! ok so I've fixed the broken programmes test. However...

I've also spotted a minor problem in the schools test. Basically the test is testing that you can't add a new school with a faculty id that doesn't exist. However the controller never makes this assumption. It just lets you do whatever. So either the test is too strict, or the controller needs bolstering.

Also... (and this is the arrgh) the programmes test is also failing because of $this->post. This is the bug I fixed a while back with the call to post, but it's been overwritten I guess during the mega-mega-merge. The same has happened with the problem in revisionable.php and assigning ids. I'll go through on Monday and pull back the stuff I'd done a couple of weeks ago.

Other than that, I think the tests work fine now for me at least.
