### PR TITLE
Basically adding features described in issue 96

### DIFF
--- a/application/controllers/api.php
+++ b/application/controllers/api.php
@@ -60,11 +60,13 @@ class API_Controller extends Base_Controller
         $modules = '';
         if (Request::env() == 'test' or Request::env() == 'local')
         {
-            $modules = json_decode(file_get_contents($path . $programme_id . '_modules_test.json'));
+            if(file_exists($path . $programme_id . '_modules_test.json'))
+                $modules = json_decode(file_get_contents($path . $programme_id . '_modules_test.json'));
         }
         else
         {
-            $modules = json_decode(file_get_contents($path . $programme_id . '_modules.json'));
+            if(file_exists($path . $programme_id . '_modules.json'))
+                $modules = json_decode(file_get_contents($path . $programme_id . '_modules.json'));
         }
         
         // build up $final which will be an object with all the data in we need
@@ -73,7 +75,8 @@ class API_Controller extends Base_Controller
         
         // modules
         // note that the web service contains two levels we won't need: response and rubric. This may need fixing once we get the finished web service
-        $final->modules = $modules->response->rubric;
+        if(!empty($modules))
+            $final->modules = $modules->response->rubric;
 
         // now add programme settings to the $final object
         // no inhertence needed so just loop through the settings, adding them to the object

--- a/application/models/programme.php
+++ b/application/models/programme.php
@@ -79,7 +79,67 @@ class Programme extends Revisionable
     }
     
     /**
-     * Get this proramme's award.
+     * Get the name of the 'get new programme' field/column in the database.
+     * 
+     * @return The name of the 'get new programme' field.
+     */
+    public static function get_new_programme_field()
+    {
+        return 'new_programme_50';
+    }
+    
+    /**
+     * Get the name of the 'mode of stude' field/column in the database.
+     * 
+     * @return The name of the 'mode of study' field.
+     */
+    public static function get_mode_of_study_field()
+    {
+        return 'mode_of_study_12';
+    }
+    
+    /**
+     * Get the name of the 'ucas code' field/column in the database.
+     * 
+     * @return The name of the 'ucas code' field.
+     */
+    public static function get_ucas_code_field()
+    {
+        return 'ucas_code_10';
+    }
+
+    /**
+     * Get the name of the 'additional school' field/column in the database.
+     * 
+     * @return The name of the 'additional school' field.
+     */
+    public static function get_additional_school_field()
+    {
+        return 'additional_school_7';
+    }
+
+    /**
+     * Get the name of the 'administrative school' field/column in the database.
+     * 
+     * @return The name of the 'administrative school' field.
+     */
+    public static function get_administrative_school_field()
+    {
+        return 'administrative_school_6';
+    }
+
+    /**
+     * Get the name of the 'location' field/column in the database.
+     * 
+     * @return The name of the 'location' field.
+     */
+    public static function get_location_field()
+    {
+        return 'location_11';
+    }
+
+    /**
+     * Get this programme's award.
      * 
      * @return Award The award for this programme.
      */
@@ -88,6 +148,45 @@ class Programme extends Revisionable
       return $this->belongs_to('Award', static::get_award_field());
     }
 
+    /**
+     * Get this programme's first subject area.
+     * 
+     * @return Subject The first subject area for this programme.
+     */
+    public function subject_area_1()
+    {
+      return $this->belongs_to('Subject', static::get_subject_area_1_field());
+    }
+
+    /**
+     * Get this programme's administrative school.
+     * 
+     * @return School The administrative school for this programme.
+     */
+    public function administrative_school()
+    {
+      return $this->belongs_to('School', static::get_administrative_school_field());
+    }
+
+    /**
+     * Get this programme's additional school.
+     * 
+     * @return School The additional school for this programme.
+     */
+    public function additional_school()
+    {
+      return $this->belongs_to('School', static::get_additional_school_field());
+    }
+
+    /**
+     * Get this programme's campus.
+     * 
+     * @return School The additional school for this programme.
+     */
+    public function location()
+    {
+      return $this->belongs_to('Campus', static::get_location_field());
+    }
     
     /**
      * look through the passed in record and substitute any ids with data from their correct table

--- a/application/models/programmerevision.php
+++ b/application/models/programmerevision.php
@@ -3,4 +3,54 @@ class ProgrammeRevision extends Eloquent
 {
     public static $table = 'programmes_revisions';
 
+    /**
+     * Get this programme's award.
+     * 
+     * @return Award The award for this programme.
+     */
+    public function award()
+    {
+      return $this->belongs_to('Award', Programme::get_award_field());
+    }
+
+    /**
+     * Get this programme's first subject area.
+     * 
+     * @return Subject The first subject area for this programme.
+     */
+    public function subject_area_1()
+    {
+      return $this->belongs_to('Subject', Programme::get_subject_area_1_field());
+    }
+
+    /**
+     * Get this programme's administrative school.
+     * 
+     * @return School The administrative school for this programme.
+     */
+    public function administrative_school()
+    {
+      return $this->belongs_to('School', Programme::get_administrative_school_field());
+    }
+
+    /**
+     * Get this programme's additional school.
+     * 
+     * @return School The additional school for this programme.
+     */
+    public function additional_school()
+    {
+      return $this->belongs_to('School', Programme::get_additional_school_field());
+    }
+
+    /**
+     * Get this programme's campus.
+     * 
+     * @return School The additional school for this programme.
+     */
+    public function location()
+    {
+      return $this->belongs_to('Campus', Programme::get_location_field());
+    }
+
 }

--- a/application/models/revisionable.php
+++ b/application/models/revisionable.php
@@ -241,7 +241,10 @@ class Revisionable extends Eloquent
     $slug_field = Programme::get_slug_field();
     $withdrawn_field = Programme::get_withdrawn_field();
     $suspended_field = Programme::get_suspended_field();
-    $subject_area_1_field = Programme::get_subject_area_1_field();
+    $subject_to_approval_field = Programme::get_subject_to_approval_field();
+    $new_programme_field = Programme::get_new_programme_field();
+    $mode_of_study_field = Programme::get_mode_of_study_field();
+    $ucas_code_field = Programme::get_ucas_code_field();
     $index_data = array();
     $programmes = ProgrammeRevision::where('year','=',$new_programme->year)
                       ->where('status','=','live')
@@ -255,7 +258,16 @@ class Revisionable extends Eloquent
         'id' => $programme->programme_id,
         'name' => $programme->$title_field,
         'slug' => $programme->$slug_field,
-        'subject' => $programme->$subject_area_1_field
+        'award' => $programme->award->name,
+        'subject' => $programme->subject_area_1->name,
+        'withdrawn' => $programme->$withdrawn_field,
+        'main_school' => $programme->administrative_school->name,
+        'secondary_school' => $programme->additional_school->name,
+        'campus' => $programme->location->name,
+        'new_programme' => $programme->$new_programme_field,
+        'subject_to_approval' => $programme->$subject_to_approval_field,
+        'mode_of_study' => $programme->$mode_of_study_field,
+        'ucas_code' => $programme->$ucas_code_field
         );
     }
     

--- a/application/routes.php
+++ b/application/routes.php
@@ -90,8 +90,8 @@ Route::group(array('before' => ''), function(){
 	Route::any('([0-9]{4})/(ug|pg)/subjectcategories/(:any?)/(:num?)', 'subjectcategories@(:3)');
 
 	// API
-	Route::any('/api/([0-9]{4})/(ug|pg)', 'api@index');
-	Route::get('/api/([0-9]{4})/(ug|pg)/(:any?)/(:num?)', 'api@(:3)');
+	Route::any('/api/([0-9]{4})/(ug|pg)/programmes', 'api@index');
+	Route::get('/api/([0-9]{4})/(ug|pg)/programmes/(:num?)', 'api@programme');
 });
 
 // Login/out


### PR DESCRIPTION
Adding this to replace https://github.com/unikent/programmes-plant/pull/102

Original text:

adding stuff from issue #96. api's index should now be accessed from:
api/2012/ug/programmes/

and a programme should be accessed from
api/2012/ug/programmes/ 1

the index also includes the following fields:

id
name
slug
award
subject
withdrawn
main_school
secondary_school
campus
new_programme
subject_to_approval
mode_of_study
ucas_code
