### PR TITLE
Fixed reordering problem with programme fields

### DIFF
--- a/application/models/programmefield.php
+++ b/application/models/programmefield.php
@@ -21,8 +21,17 @@ class ProgrammeField extends Field
     	return $list_types;
     }
     
+    /**
+     * Gets programme sections and fields in an array
+     *
+     * gets all programme sections and the fields within each, and orders the sections by their order value
+     * a double-loop then goes through each section and builds up an array of ordered fields
+     *
+     * @return array $sections_array
+     */
     public static function programme_fields_by_section()
     {
+        // get the section and field data
         $sections = ProgrammeSection::with('programmefields')->order_by('order','asc')->get();
 
         $sections_array = array();
@@ -31,11 +40,15 @@ class ProgrammeField extends Field
         {
             foreach ($section->programmefields as $programmefield)
             {
+                // make sure the section is active
                 if ($section->id > 0)
                 {
-                    $sections_array[$section->name][] = $programmefield;
+                    // build up the final array indexed by section name and programme field order
+                    $sections_array[$section->name][$programmefield->order] = $programmefield;
                 }
             }
+            // sort each section sub-array so that the fields are in the correct order
+            if (isset($sections_array[$section->name])) ksort($sections_array[$section->name]);
         }
         return $sections_array;
     }

--- a/application/tests/models/programmefield.test.php
+++ b/application/tests/models/programmefield.test.php
@@ -16,12 +16,7 @@ class TestProgrammeField extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
-		$programme_fields = ProgrammeField::all();
 
-		foreach ($programme_fields as $programme_field)
-		{
-			$programme_field->delete();
-		}
 	}
 
 	/**
@@ -51,6 +46,34 @@ class TestProgrammeField extends PHPUnit_Framework_TestCase {
 		
 		// check if the order of id-1 has now changed to 2
 		$this->assertEquals($programme_field->order, '2', "ProgrammeField::reorder did not return the correct ordering.");
+	}
+	
+	
+	/**
+	* Tests that programme fields are returned in the expected section and ordering
+	* 
+	* while testReorderFields() tests that ordering is correctly set for a specific field, this test makes sure the array of all sections and fields is correct. This ensures that the programme edit/create page displays the fields in the correct order
+	*
+	* @covers ProgrammeField::programme_fields_by_section()
+	*/
+	public function testProgrammeFieldsBySection()
+	{
+    	// reorder the first 3 fields in section 1 so they're id3, id2, then id1
+		$order_string = 'field-id-3,field-id-2,field-id-1';
+		ProgrammeField::reorder($order_string, 1);
+		
+		// get the programme fields
+		$programme_fields = ProgrammeField::programme_fields_by_section();
+		
+		// test that 'Programme title and key facts' is the first section name
+		$keys = array_keys($programme_fields);
+		$this->assertEquals('Programme title and key facts', $keys[0]);
+		
+		// check that field #1 has id 3, field #2 has id 2, and field #3 has id 1
+		$this->assertEquals(3, $programme_fields['Programme title and key facts'][1]->id);
+		$this->assertEquals(2, $programme_fields['Programme title and key facts'][2]->id);
+		$this->assertEquals(1, $programme_fields['Programme title and key facts'][3]->id);
+				
 	}
 
 }


### PR DESCRIPTION
Now correctly pulls out the field order value into the section/programmefield array so that both sections and fields can be correctly ordered. Wrote a test to make sure reordering works ok.
