### PR TITLE
Thin API Controller

### DIFF
--- a/application/controllers/api.php
+++ b/application/controllers/api.php
@@ -19,97 +19,39 @@ class API_Controller extends Base_Controller {
 	*/
 	public function get_index($year, $level)
 	{
-		$path = path('storage') . 'api/' . $level . '/' . $year . '/';
+		$json_index = Programme::json_index($year, $level);
 
 		// 204 is the HTTP code for No Content - the result processed fine, but there was nothing to return.
-		if (! file_exists($path . 'index.json'))
+		if (! $json_index)
 		{
 			return Response::error('204');
 		}
 
 		// Return the cached index file with the correct headers.
-		return Response::make(file_get_contents($path . 'index.json'), '200', array('Content-Type' => 'application/json'));
+		return Response::make($json_index, '200', array('Content-Type' => 'application/json'));
 	}
 	
 	/**
-	* get data for the programme
+	* Get data for the programme as JSON.
 	*
-	* @param $year
-	* @param $level - ug or pg
-	* @param $programme_id - the programme we're pulling data for
-	* @return json data as a string or HTTP response    
+	* @param string $year The Year.
+	* @param string $level The level - ug or pg.
+	* @param $programme_id The programme we're pulling data for.
+	* @return json data as a string or HTTP response.    
 	*/
 	public function get_programme($year, $level, $programme_id)
 	{
-		// set up the path to the output/cache file
-		$path = path('storage') . 'api/' . $level . '/' . $year . '/';
-		
-		// try to get json files for global and programme settings, as well as the programme data itself
+		$programme = Programme::get_as_flattened($year, $level, $programme_id);
+
 		// 204 is the HTTP code for No Content - the result processed fine, but there was nothing to return.
-		if (! file_exists($path . 'globalsetting.json') or ! file_exists($path . 'programmesetting.json') or ! file_exists($path . $programme_id . '.json') )
+		// This is the case if certain aspects are not in place for our JSON.
+		if (! $programme)
 		{
 			return Response::error('204');
 		}
-
-		// if the cache files do exist for global/programme settings and the programme data, put them into objects
-		$global_settings = json_decode(file_get_contents($path . 'globalsetting.json'));
-		$programme_settings = json_decode(file_get_contents($path . 'programmesetting.json'));
-		$programme = json_decode(file_get_contents($path . $programme_id . '.json'));
-		
-		// in local and test environments we're using a faked json file rather than one generated from the sds web service
-		$modules = '';
-		if (Request::env() == 'test' or Request::env() == 'local')
-		{
-			if(file_exists($path . $programme_id . '_modules_test.json'))
-				$modules = json_decode(file_get_contents($path . $programme_id . '_modules_test.json'));
-		}
-		else
-		{
-			if(file_exists($path . $programme_id . '_modules.json'))
-				$modules = json_decode(file_get_contents($path . $programme_id . '_modules.json'));
-		}
-		
-		// build up $final which will be an object with all the data in we need
-		// start with the global settings
-		$final = $global_settings;
-		
-		// modules
-		// note that the web service contains two levels we won't need: response and rubric. This may need fixing once we get the finished web service
-		if(!empty($modules))
-		{
-			$final->modules = $modules->response->rubric;
-		}
-			
-		// now add programme settings to the $final object
-		// no inheritance needed so just loop through the settings, adding them to the object
-		foreach($programme_settings as $key => $value)
-		{
-			$final->{$key} = $value;
-		}
-
-		// pull in all programme dependencies eg an award id 1 will pull in all that award's data
-		// loop through them, adding them to the $final object
-		$programme = Programme::pull_external_data($programme);
-		foreach($programme as $key => $value)
-		{
-			// make sure any existing key in the $final object gets updated with the new $value
-			if(!empty($value) ){
-				$final->{$key} = $value;
-			}
-		}
-		
-		// tidy up
-		foreach(array('id','global_setting_id') as $key)
-		{
-			unset($final->{$key});
-		}
-		
-		// now remove ids from our field names, they're not necessary
-		// eg 'programme_title_1' simply becomes 'programme_title'
-		$final = Programme::remove_ids_from_field_names($final);
 		
 		// return a JSON version of the newly-created $final object
-		return Response::json($final);
+		return Response::json($programme);
 	}
 
 }

--- a/application/models/programme.php
+++ b/application/models/programme.php
@@ -256,5 +256,106 @@ class Programme extends Revisionable {
 
 		return $values;
 	}
-	
+
+	/**
+	 * Returns the JSONified index of programmes for a given year.
+	 * 
+	 * @param string $year The year of the programmes.
+	 * @param string $level The level of the programmes, ug (undergraduate) or pg (postgraduate)
+	 * @return string The JSON index directly from disc cache.
+	 */
+	public static function json_index($year, $level)
+	{
+		$path = path('storage') . 'api/' . $level . '/' . $year . '/';
+
+		if (! file_exists($path . 'index.json'))
+		{
+			return false;
+		}
+
+		return file_get_contents($path . 'index.json');
+	}
+
+	/**
+	 * Get flattened data for a programme from the JSON disc cache.
+	 * 
+	 * @param string $year The year of the programme.
+	 * @param string $level The level of the programme, ug (undergraduate) or pg (postgraduate).
+	 * @param int $programme_id The ID of the programme.
+	 * @return Object $final | false The object as an array with relevant data attached. or false if we had problems.
+	 */
+	public static function get_as_flattened()
+	{
+		// Set up the path to the output/cache file.
+		$path = path('storage') . 'api/' . $level . '/' . $year . '/';
+		
+		// Try to get JSON files for global and programme settings, as well as the programme data itself.
+		// If 
+		if (! file_exists($path . 'globalsetting.json') or ! file_exists($path . 'programmesetting.json') or ! file_exists($path . $programme_id . '.json') )
+		{
+			return false;
+		}
+
+		// If the cache files do exist for global/programme settings and the programme data, put them into objects.
+		$global_settings = json_decode(file_get_contents($path . 'globalsetting.json'));
+		$programme_settings = json_decode(file_get_contents($path . 'programmesetting.json'));
+		$programme = json_decode(file_get_contents($path . $programme_id . '.json'));
+		
+		// In local and test environments we're using a faked JSON file rather than one generated from the sds web service.
+		$modules = '';
+		if (Request::env() == 'test' or Request::env() == 'local')
+		{
+			if(file_exists($path . $programme_id . '_modules_test.json'))
+			{
+				$modules = json_decode(file_get_contents($path . $programme_id . '_modules_test.json'));
+			}
+		}
+		else
+		{
+			if(file_exists($path . $programme_id . '_modules.json'))
+			{
+				$modules = json_decode(file_get_contents($path . $programme_id . '_modules.json'));
+			}
+		}
+		
+		// Build up $final which will be an object with all the data in we need.
+		// Start with the global settings.
+		$final = $global_settings;
+		
+		// Modules
+		// Note that the web service contains two levels we won't need: response and rubric. This may need fixing once we get the finished web service.
+		if(!empty($modules))
+		{
+			$final->modules = $modules->response->rubric;
+		}
+			
+		// Add programme settings to the $final object
+		// No inheritance needed so just loop through the settings, adding them to the object.
+		foreach($programme_settings as $key => $value)
+		{
+			$final->{$key} = $value;
+		}
+
+		// Pull in all programme dependencies eg an award id 1 will pull in all that award's data.
+		// Loop through them, adding them to the $final object.
+		$programme = Programme::pull_external_data($programme);
+
+		foreach($programme as $key => $value)
+		{
+			// Make sure any existing key in the $final object gets updated with the new $value.
+			if(!empty($value) ){
+				$final->{$key} = $value;
+			}
+		}
+		
+		// Tidy up.
+		foreach(array('id','global_setting_id') as $key)
+		{
+			unset($final->{$key});
+		}
+		
+		// Now remove IDs from our field names, they're not necessary and return.
+		// e.g. 'programme_title_1' simply becomes 'programme_title'.
+		return Programme::remove_ids_from_field_names($final);
+	}
 }


### PR DESCRIPTION
This thins out the API controller, abstracting much of the methodology to the Programme model. Part of a blind alley I pursued trying to fulfil #172 

Eventually we will need to rethink this whole code. It made sense to save JSON to disc when the only output was JSON. Now the output is roughly the same forms of data, but as XML (XCRI-CAP) and JSON much of the code no longer makes sense and causes repetition.
