### PR TITLE
fix programme listing paging bug

### DIFF
--- a/public/js/programmes-plant.js
+++ b/public/js/programmes-plant.js
@@ -293,8 +293,8 @@ function init_dataTable(){
             "sSearch": ""
         },
         "aoColumns": [ 
-            { "bSortable": false, 'iDataSort': false },
-            { "bSortable": false, 'iDataSort': true },
+            { "bSortable": false, 'iDataSort': 1 },
+            { "bSortable": false},
             { "bSortable": false }
           ]
     });


### PR DESCRIPTION
it seemed the iDataSort attribute was being used incorrectly, and therefore breaking paging on the datatable. this should make paging work again
