### PR TITLE
fixed staff index page ordering

### DIFF
--- a/application/controllers/staff.php
+++ b/application/controllers/staff.php
@@ -5,6 +5,17 @@ class Staff_Controller extends Simple_Admin_Controller {
 	public $model = 'Staff';
 	public $custom_form = true;
 
+	/**
+	 * Return all data and send to an index view.
+	 */
+	public function get_index()
+	{
+		$model = $this->model;
+
+		$this->data['items'] = $model::all_active('surname');
+		$this->data['shared'] = $this->shared_data;
+		$this->layout->nest('content', 'admin.indexes.simple-index', $this->data);
+	}
 
 	/**
 	 * Create a new item via POST.

--- a/application/models/simpledata.php
+++ b/application/models/simpledata.php
@@ -270,8 +270,12 @@ class SimpleData extends Eloquent {
 		return $values;
 	}
 	
-	public static function all_active()
+	public static function all_active($sort_by='')
 	{
+		if ($sort_by != '')
+		{
+			return static::where('hidden', '=', false)->order_by($sort_by, 'asc')->get();
+		}
 		return static::where('hidden', '=', false)->get();
 	}
 	


### PR DESCRIPTION
closes #495 
- added an override for get_index instead of using the simpleadmin default
- modified simpledata all_active() to have an optional ordering param
