### PR TITLE
Trim options for select fields before saving.

### DIFF
--- a/application/migrations/2015_02_12_091635_trim_field_options.php
+++ b/application/migrations/2015_02_12_091635_trim_field_options.php
@@ -1,0 +1,39 @@
+<?php
+
+class Trim_Field_Options {
+
+	/**
+	 * Make changes to the database.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		// for UG select fields
+		$ug_fields = UG_ProgrammeField::where('field_type', '=', 'select')->get();
+
+		foreach ($ug_fields as $ug_field) {
+			DB::query("UPDATE programmes_revisions_ug SET `{$ug_field->colname}` = trim(`{$ug_field->colname}`)");
+			DB::query("UPDATE programmes_ug SET `{$ug_field->colname}` = trim(`{$ug_field->colname}`)");
+		}
+
+		// for PG select fields
+		$pg_fields = PG_ProgrammeField::where('field_type', '=', 'select')->get();
+
+		foreach ($pg_fields as $ug_field) {
+			DB::query("UPDATE programmes_revisions_pg SET `{$ug_field->colname}` = trim(`{$ug_field->colname}`)");
+			DB::query("UPDATE programmes_pg SET `{$ug_field->colname}` = trim(`{$ug_field->colname}`)");
+		}
+	}
+
+	/**
+	 * Revert the changes to the database.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		// We dont need this to be reversible
+	}
+
+}

--- a/application/views/admin/inc/partials/formfields.php
+++ b/application/views/admin/inc/partials/formfields.php
@@ -36,8 +36,12 @@ foreach($section as $field):
       switch($type){
 
         case 'select':
-          $options_list = explode(',',$field->field_meta);
+          $options_list = array();
+          foreach (explode(',',$field->field_meta) as $option) {
+            $options_list[] = trim($option);
+          }
           asort($options_list);
+          
           $form_element = Form::$tip($column_name, array_combine( $options_list, $options_list), $current_value);
           break;
 


### PR DESCRIPTION
Trim out select options so they are saved without beginning or trailing spaces. 
And migrate the options that have already been saved with spaces.

This shouldn't affect the front end but should be tested on www-test (with and without clearing caches) in any case.