### PR TITLE
Fix/related courses

### DIFF
--- a/application/models/api.php
+++ b/application/models/api.php
@@ -87,8 +87,7 @@ class API {
 
 	/**
 	* Return fully combined programme item from the API
-	* @TODO $id seems to be $iid here - confirm
-	* @param id ID of programme
+	* @param id the instance ID of programme
 	* @param year Year to get index for
 	* @return combined Programme data array
 	*/

--- a/application/models/api.php
+++ b/application/models/api.php
@@ -87,7 +87,7 @@ class API {
 
 	/**
 	* Return fully combined programme item from the API
-	*
+	* @TODO $id seems to be $iid here - confirm
 	* @param id ID of programme
 	* @param year Year to get index for
 	* @return combined Programme data array
@@ -365,7 +365,6 @@ class API {
 		}else{
 			$final['modules'] = $modules;
 		}
-
 
 		return $final;
 	}
@@ -646,6 +645,7 @@ class API {
 	* Creates a flat representation of a programme for use in XCRI.
 	*
 	* @return StdClass A flattened and simplified XCRI ready representation of this object.
+	* @todo: $id seems to be $iid - can we confirm???
 	*/
 	public static function get_xcrified_programme($id, $year, $type = false)
 	{

--- a/application/models/programme.php
+++ b/application/models/programme.php
@@ -891,4 +891,20 @@ abstract class Programme extends Revisionable {
 		return $years;
 	}
 
+	/**
+	 * Gives a flat array of instance_id => item_title for all items.
+	 * 
+	 * wraps around simpledata::all_as_list
+	 * 
+	 * @param string $year The year from which to get the array.
+	 *
+	 * @param boolean $empty_default_value some select lists can have an empty 'please select' or 'none' value in them. Defaults to false.
+	 * 
+	 * @return array $options List of items in the format id => item_title.
+	 *
+	 */
+	public static function all_as_list($year, $empty_default_value = 0) {
+		return  parent::all_as_list($year, 0, "instance_id");
+	}
+
 }

--- a/application/models/programme.php
+++ b/application/models/programme.php
@@ -899,12 +899,20 @@ abstract class Programme extends Revisionable {
 	 * @param string $year The year from which to get the array.
 	 *
 	 * @param boolean $empty_default_value some select lists can have an empty 'please select' or 'none' value in them. Defaults to false.
+	 *
+	 * @param string $id_field - this is ignored - see comments below
 	 * 
 	 * @return array $options List of items in the format id => item_title.
 	 *
 	 */
-	public static function all_as_list($year, $empty_default_value = 0) {
-		return  parent::all_as_list($year, 0, "instance_id");
+	public static function all_as_list($year = false, $empty_default_value = 0, $id_field = 'id') {
+		/*
+		 this deliberatly ignores the id_field to always prefer to use 'instance_id'
+
+		 However, since simpledata->all_as_list has a default set we need to keep the 
+		 same defaults here to prevent a php warning.
+		*/
+		return  parent::all_as_list($year, $empty_default_value, 'instance_id');
 	}
 
 }

--- a/application/models/simpledata.php
+++ b/application/models/simpledata.php
@@ -81,10 +81,12 @@ abstract class SimpleData extends Eloquent {
 	 * @param string $year The year from which to get the array.
 	 *
 	 * @param boolean $empty_default_value some select lists can have an empty 'please select' or 'none' value in them. Defaults to false.
-	 *
+	 * 
 	 * @return array $options List of items in the format id => item_title.
+	 *
+	 * @param string $id_field the field to use as the ID if you need to override it with for instance 'instance_id'.  Defaults to 'id'
 	 */
-	public static function all_as_list($year = false, $empty_default_value = 0)
+	public static function all_as_list($year = false, $empty_default_value = 0, $id_field = 'id')
 	{
 		$model = get_called_class();
 
@@ -96,7 +98,7 @@ abstract class SimpleData extends Eloquent {
 
 		if (isset(static::$list_cache[$cache_key])) return static::$list_cache[$cache_key];
 		
-		return static::$list_cache[$cache_key] = Cache::remember($cache_key, function() use ($year, $model, $empty_default_value)
+		return static::$list_cache[$cache_key] = Cache::remember($cache_key, function() use ($year, $model, $empty_default_value, $id_field)
 		{
 			$options = array();
 			// set the 'none' select value, as per the $empty_default_value param
@@ -112,7 +114,7 @@ abstract class SimpleData extends Eloquent {
 				$list_fields = $model::$list_fields;
 			}else{
 				// else just use id and title
-				$list_fields = array('id', $title_field);
+				$list_fields = array($id_field, $title_field);
 			}
 
 			if (! $year)
@@ -126,7 +128,7 @@ abstract class SimpleData extends Eloquent {
 
 			foreach ($data as $record)
 			{
-				$options[$record->id] = $record->$title_field;
+				$options[$record->$id_field] = $record->$title_field;
 			}
 
 			return $options;

--- a/application/tasks/related-courses.php
+++ b/application/tasks/related-courses.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+	2018-07-10 
+	this is a one off task to update the IDs used for the related courses 
+
+	Situation was that the IDs which has been saved for the related courses where the course ids rather than their instance ids
+	done as part of https://github.com/unikent/programmes-plant/pull/959
+	
+	usage:
+	
+	// to see the current state of all the courses and their related courses
+	php artisan related-courses:view 
+	
+	// to update the related courses so that they are related by instance id rather than id
+	php artisan related-courses:update
+	
+	// @TODO - saving the programmes in the update function is not working yet!
+	
+	See Christian for more details if needed
+
+*/
+class Related_Courses_Task {
+
+	public function run($arguments = array())
+	{
+		print_r($arguments);
+	}
+
+	
+	private function getProgramme($id, $level = 'ug')
+	{
+		$programmes_table = "programmes_$level";
+		$programmes_model = strtoupper($level) . '_Programme';
+		$programme_title_field = $programmes_model::get_programme_title_field();
+		$programme = DB::table($programmes_table)->where('id', '=', $id)->first();
+
+		return $programme;
+	}
+
+
+	public function view($arguments = array())
+	{
+		Auth::login(1);
+
+		$levels = array('ug', 'pg');
+
+		foreach($levels as $level) {
+			$programmesTable = "programmes_$level";
+			$programmesModel = strtoupper($level) . '_Programme';
+			$related_courses_field = $programmesModel::get_related_courses_field();
+			$programme_title_field = $programmesModel::get_programme_title_field();
+		
+			foreach(DB::table($programmesTable)->get() as $programme) {
+				$relatedCoursesIDs = trim($programme->$related_courses_field, ',');
+	
+				if (strlen($relatedCoursesIDs) !== 0) {
+					$relatedCoursesIDsArray =  explode(',', $relatedCoursesIDs);
+					echo "\n{$programme->$programme_title_field} is related to programmes: $relatedCoursesIDs \n";
+					foreach($relatedCoursesIDsArray as $relatedCourseID) {
+						$relatedCourse = static::getProgramme($relatedCourseID, $level);
+						echo "\tID: $relatedCourseID - InstanceID: {$relatedCourse->instance_id}\t{$relatedCourse->$programme_title_field}\n";
+					}
+				}
+			}
+		}	
+	}
+
+
+	public function update()
+	{
+		Auth::login(1);
+
+		$levels = array('ug', 'pg');
+
+		foreach($levels as $level) {
+			$programmesTable = "programmes_$level";
+			$programmesModel = strtoupper($level) . '_Programme';
+			$related_courses_field = $programmesModel::get_related_courses_field();
+			$programme_title_field = $programmesModel::get_programme_title_field();
+		
+			foreach(DB::table($programmesTable)->get() as $programme) {
+				$relatedCoursesIDs = trim($programme->$related_courses_field, ',');
+	
+				if (strlen($relatedCoursesIDs) !== 0) {
+					$relatedCoursesIDsArray =  explode(',', $relatedCoursesIDs);
+					echo "\n{$programme->$programme_title_field} is related to programmes: $relatedCoursesIDs \n";
+
+					$updatedRelatedCoursesIDsArray = array();
+					
+					foreach($relatedCoursesIDsArray as $relatedCourseID) {
+						$relatedCourse = static::getProgramme($relatedCourseID, $level);
+						echo "\tID: $relatedCourseID - InstanceID: {$relatedCourse->instance_id}\t{$relatedCourse->$programme_title_field}\n";
+						$updatedRelatedCoursesIDsArray[] = $relatedCourse->instance_id;
+					}
+
+					// the original data began with a ',' so I'm keeping that here 
+					$updatedRelatedCoursesIDs = ',' . implode(',', $updatedRelatedCoursesIDsArray);
+					echo "Updating with: $updatedRelatedCoursesIDs\n\n";
+					$programme->$related_courses_field = implode(',', $updatedRelatedCoursesIDsArray);
+					
+					// @TODO this isn't working yet
+					$programme->save();
+				}
+			}
+		}	
+	}
+}
+	

--- a/application/tasks/related-courses.php
+++ b/application/tasks/related-courses.php
@@ -15,8 +15,6 @@
 	// to update the related courses so that they are related by instance id rather than id
 	php artisan related-courses:update
 	
-	// @TODO - saving the programmes in the update function is not working yet!
-	
 	See Christian for more details if needed
 
 */

--- a/application/tests/models/api.test.php
+++ b/application/tests/models/api.test.php
@@ -2,26 +2,8 @@
 
 class TestAPI extends ModelTestCase 
 {
-	/*
-		keep track of instance_ids already generated in test data
-	*/
-	public static $random_numbers;
-
-	public static function unique_rand($min = 0, $max = 100)
-	{
-		/*
-			instance_id is stored as int(11) so just use current unix timestamp if duplicate generated
-			NOTE: potential year 5138 problem
-		*/
-		$number = rand($min, $max);
-		if (in_array($number, self::$random_numbers, true)) {
-			sleep(1); //ensure that time passes
-			$number = time();
-		}
-		array_push(self::$random_numbers, $number);
-	
-		return $number;
-	}
+	// used to keep id and instance_id different
+	public static $instance_id_offset; 
 
 	public static function test_programme ()
 	{
@@ -29,7 +11,7 @@ class TestAPI extends ModelTestCase
 			'programme_title_1' => 'Thing',
 			'year' => "2014",
 			'hidden' => 0,
-			'instance_id' => self::unique_rand(10,10000),
+			'instance_id' => self::$instance_id_offset++,
 			UG_Programme::get_programme_suspended_field() => '',
 			UG_Programme::get_programme_withdrawn_field() => '',
 			UG_Programme::get_subject_area_1_field()  => '1',
@@ -45,7 +27,7 @@ class TestAPI extends ModelTestCase
 	public static function setUpBeforeClass()
 	{
 		Tests\Helper::migrate();
-		self::$random_numbers = array();
+		self::$instance_id_offset = 10;
 
 		// Remove all elements in the awards table.
 		// These are added by the Create_Intial_Awards migration.

--- a/paths.php
+++ b/paths.php
@@ -22,7 +22,7 @@
 */
 
 $environments = array(
-	'local' => array('http://plant.test:8080*', '*.test:8080', '*.test', '*.dev', '*.local', '*.local:9000', '192.168*', '*.vg'),
+	'local' => array('http://localhost*', '*.dev', '*.local', '*.local:9000', '192.168*', '*.vg', '*.test'),
 	'test' => array('')
 );
 

--- a/paths.php
+++ b/paths.php
@@ -22,7 +22,7 @@
 */
 
 $environments = array(
-	'local' => array('http://localhost*', '*.dev', '*.local', '*.local:9000', '192.168*', '*.vg'),
+	'local' => array('http://plant.test:8080*', '*.test:8080', '*.test', '*.dev', '*.local', '*.local:9000', '192.168*', '*.vg'),
 	'test' => array('')
 );
 

--- a/public/js/kent-texteditor.js
+++ b/public/js/kent-texteditor.js
@@ -636,7 +636,15 @@ var redactor_config = {
 		}
 	},
 	maxHeight: 600,
-	videoContainerClass: 'embed-responsive embed-responsive-16by9'
+	videoContainerClass: 'embed-responsive embed-responsive-16by9',
+	callbacks: {
+		    paste: function(html)
+		    {
+		//       console.log(html,this.block.removeAttr('style'));
+		      console.log(html);
+		      return html;
+		    }
+		  }  
 };
 
 $('textarea').not('.picker').each( function(){

--- a/public/js/kent-texteditor.js
+++ b/public/js/kent-texteditor.js
@@ -636,15 +636,7 @@ var redactor_config = {
 		}
 	},
 	maxHeight: 600,
-	videoContainerClass: 'embed-responsive embed-responsive-16by9',
-	callbacks: {
-		    paste: function(html)
-		    {
-		//       console.log(html,this.block.removeAttr('style'));
-		      console.log(html);
-		      return html;
-		    }
-		  }  
+	videoContainerClass: 'embed-responsive embed-responsive-16by9'
 };
 
 $('textarea').not('.picker').each( function(){

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,8 @@ To run all the seeds type `php artisan seed --env=local`.
 
 Unit tests are written in PHPUnit. To run the tests run `php artisan test`. The tests use an in memory SQLite database to make them significantly faster.
 
+If PHPUnit is not in your path then add it by `export PATH=$PATH:`pwd`/bin` from the programmes-plant directory.
+
 ## API
 
 The JSON API exposes data endpoints that can be consumed for external application. Here is a brief summary of the endpoints available. These endpoints should be prefixed with the application's base url. A more thorough list can be found in the [routes.php](application/routes.php) file.


### PR DESCRIPTION
## Problem
The related courses were only including the courses from the subject areas. 

## Fault
This was due to those courses which were manually related using the id of the course rather than the 'instance_id'

In the past the concept of 'Instance ID' (the ID of the first instance of a programme) was introduced to provide a stable ID between the same programme running across different years. 

## Fixes 

### Update Tests to use Instance ID rather than ID

The tests were using ID of the programme in their sample data. This effectively hid this problem from the tests. 

### When adding related programmes, relate them via 'Instance ID'

This fix updates the edit programme screen to use the instance_id for the related courses select.

### Updating Existing Incorrect Relations

Also included is an artisan task to review the current state of the related courses and to update them so that related courses refer to the instance ID rather than the ID.

`php artisan related-courses:view`
to view the existing relationships 

`php artisan related-courses:update`
to update related courses so that they use the instance ID rather than ID