### PR TITLE
Modify programmes plant import tasks to use new sits api stuff

### DIFF
--- a/application/migrations/2018_07_06_091720_add_crs_code_to_deliveries_for_sits_integrations.php
+++ b/application/migrations/2018_07_06_091720_add_crs_code_to_deliveries_for_sits_integrations.php
@@ -1,0 +1,34 @@
+<?php
+
+class Add_Crs_Code_To_Deliveries_For_Sits_Integrations {
+
+	/**
+	 * Make changes to the database.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('ug_programme_deliveries', function($table) {
+			$table->string('crs_code',50)->nullable();
+		});
+		Schema::table('pg_programme_deliveries', function($table) {
+			$table->string('crs_code',50)->nullable();
+		});
+	}
+
+	/**
+	 * Revert the changes to the database.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('ug_programme_deliveries', function($table) {
+			$table->dropColumn('crs_code');
+		});
+		Schema::table('pg_programme_deliveries', function($table) {
+			$table->dropColumn('crs_code');
+		});	}
+
+}


### PR DESCRIPTION
Change the moduledata and sitsimport tasks to import from api.kent's new sits database-based json data.

moduledata task:
 * retrieve rubric / module diet data from api's /sits/modulediet route instead of the old sds posRubric API
 * use the course id (crs_code) instead of the old pos code for this query

sitsimport task
 * now adds crs_code to the deliveries it saves
 * code formatting "improved" so whoops sorry my bad hard to see where the changes are...

These rely on the latest changes to api.kent's sits-integration branch

Needs php artisan migrate running to add crs_code field.