### PR TITLE
Add route to export all fields from programmes_(ug|pg) table for specific years.

### DIFF
--- a/application/routes.php
+++ b/application/routes.php
@@ -210,7 +210,7 @@ Route::group(array('before' => ''), function(){
     Route::get('/export/([0-9]{4}|current)/(undergraduate|postgraduate)/pos-codes', 'api@export_poscodes'); // get pos code list per programme
     Route::get('/export/([0-9]{4}|current)/(undergraduate|postgraduate)/(taught|research|taught-research)/pos-codes', 'api@export_poscodes'); // get pos code list per programme
 
-
+	Route::get('/export/([0-9]{4}|current)/(undergraduate|postgraduate)/all-fields', 'api@export_allfields'); // get all fields for all courses
 });
 
 // Login/out


### PR DESCRIPTION
Routes are:

/export/(<year>|current))/(undergraduate|postgraduate)/all-fields

Data is exported as a csv download.