### PR TITLE
Feature/clusters of modules indicate which delivery they belong to

### DIFF
--- a/application/controllers/programmes.php
+++ b/application/controllers/programmes.php
@@ -128,7 +128,8 @@ class Programmes_Controller extends Revisionable_Controller {
 		$model = $this->model;
 
 		// Ensure we have a corresponding course in the database
-		$programme = $model::where('instance_id', '=', $id)->where('year', '=', $year)->first();
+		$programme = $model::where('instance_id', '=', $id)->where('year', '=', $year);
+			$programme = $programme->first();
 
 		if (! $programme) return Redirect::to($year . '/' . $type . '/' . $this->views);
 		

--- a/application/models/api.php
+++ b/application/models/api.php
@@ -457,10 +457,12 @@ class API {
 
 
 		// For each column with a special data type, update its value in the record;
-		foreach($programme_fields as $field_name => $data_type){
-
-			$record[$field_name] = $data_type::replace_ids_with_values($record[$field_name], $record['year'], false, ($data_type=='Image'));
-
+		foreach ($programme_fields as $field_name => $data_type) {
+			// avoid replacing ids when we do not have a field_name or data_type
+			if (strlen($field_name) && strlen($data_type)) {
+				$record[$field_name]
+					= $data_type::replace_ids_with_values($record[$field_name], $record['year'], false, ($data_type=='Image'));
+			}
 		}
 
 		return $record;

--- a/application/models/api.php
+++ b/application/models/api.php
@@ -353,7 +353,13 @@ class API {
 			$delivery['fees'] = Fees::getCondensedFeeInfoForPos($delivery['pos_code'], $final['globals']['fees_year']);
 
 			// Add modules
-			$modules[] = API::get_module_data($programme['instance_id'], $delivery['pos_code'], $programme['year'], $level);
+			// inject the some delivery information here so we can choose between different deliveries in of-course easier
+			$tmp_modules = API::get_module_data($programme['instance_id'], $delivery['pos_code'], $programme['year'], $level);
+			$tmp_modules->attendance_pattern = $delivery['attendance_pattern'];
+			$tmp_modules->award_name = $delivery['award_name'];
+			$tmp_modules->mcr = $delivery['mcr'];
+			$tmp_modules->pos_code = $delivery['pos_code'];
+			$modules[] = $tmp_modules;
 		}
 
 

--- a/application/models/delivery.php
+++ b/application/models/delivery.php
@@ -10,6 +10,11 @@ abstract class Delivery extends SimpleData
 		return $success;
 	}
 
+	public function relatedaward()
+	{
+		return $this->award();
+	}
+
 	public function delete(){
 		$programme_model = static::$level . "_programme";
 		$p = $programme_model::where('id','=',$this->programme_id)->first(array('id','instance_id','year'));

--- a/application/models/pg/delivery.php
+++ b/application/models/pg/delivery.php
@@ -3,5 +3,4 @@ class PG_Delivery extends Delivery
 {
 	public static $table = 'pg_programme_deliveries';
 	public static $level = 'pg';
-
 }

--- a/application/models/pg/programme.php
+++ b/application/models/pg/programme.php
@@ -4,4 +4,77 @@ class PG_Programme extends Programme {
 	public static $table = 'programmes_pg';
 	public static $revision_model = 'PG_ProgrammeRevision';
 	public static $type = 'pg';
+
+	static $AWARD_RANKINGS = array(
+		'phd' => 12,
+		'sportd' => 11,
+		'engd' => 10,
+		'mphil' => 9,
+		'mba' => 8,
+		'llm' => 7,
+		'msc' => 6,
+		'march' => 5,
+		'ma' => 4,
+		'pdip' => 3,
+		'pcert' => 2,
+		'gdip' => 1,
+	);
+
+	/**
+	 * Gets the delivery which has been set as the preferred delivery.
+	 * @param array|null $deliveries - Array of deliveries to search in OR null, in which case all deliveries for this program are used.
+	 * @return PG_Delivery|null - The delivery or null if no preferred delivery is set.
+	 */
+	public function getPreferredDelivery($deliveries = null)
+	{
+		$deliveries = (null === $deliveries) ? $this->deliveries()->with('award')->get() : $deliveries;
+		$mcr_field = static::get_display_course_structure_mcr_field();
+		$award_field = static::get_display_course_structure_award_field();
+		$pattern_field = static::get_display_course_structure_attendance_pattern_field();
+		foreach($deliveries as $delivery) {
+			if($this->$mcr_field) {
+				if($delivery->mcr === $this->$mcr_field) {
+					return $delivery;
+				}
+			}
+			else {
+				$award = $delivery->award()->first();
+				if($award && $award->name === $this->$award_field
+				&& $this->$pattern_field === $delivery->attendance_pattern) {
+					return $delivery;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Gets the delivery that would be the default if not overridden (regardless of whether one has been set yet).
+	 * @param array|null $deliveries - Array of deliveries to search in OR null, in which case all deliveries for this program are used.
+	 * @return PG_Delivery|null - The delivery that would be preferred by default or null if none exists.
+	 */
+	public function getDefaultDelivery($deliveries = null)
+	{
+		$default = null;
+		$deliveries = (null === $deliveries) ? $this->deliveries()->with('award')->get() : $deliveries;
+		$n_deliveries = is_array($deliveries) ? count($deliveries) : 0;
+		if($n_deliveries) {
+			$default = $deliveries[0];
+			$award_obj = $default->award()->first();
+			$award = $award_obj ? strtolower($award_obj->name) : '';
+			$top_ranking = isset(self::$AWARD_RANKINGS[$award]) ? self::$AWARD_RANKINGS[$award] : 0;
+			for ($i = 1; $i < $n_deliveries; $i++) {
+				$award_obj = $deliveries[$i]->award()->first();
+				$award = $award_obj ? strtolower($award_obj->name) : '';
+				$ranking = isset(self::$AWARD_RANKINGS[$award]) ? self::$AWARD_RANKINGS[$award] : 0;
+				if($ranking > $top_ranking) {
+					$default = $deliveries[$i];
+					$top_ranking = $ranking;
+				}
+			}
+		}
+		return $default;
+	}
+
+
 }

--- a/application/tasks/default-delivery.php
+++ b/application/tasks/default-delivery.php
@@ -1,0 +1,178 @@
+<?php
+
+class Default_Delivery_Task
+{
+	static $AWARD_RANKINGS = array(
+		'phd' => 12,
+		'sportd' => 11,
+		'engd' => 10,
+		'mphil' => 9,
+		'mba' => 8,
+		'llm' => 7,
+		'msc' => 6,
+		'march' => 5,
+		'ma' => 4,
+		'pdip' => 3,
+		'pcert' => 2,
+		'gdip' => 1,
+	);
+
+	public function run($arguments = array())
+	{
+		$arguments = $this->parseArguments($arguments);
+		$programmes = PG_Programme::with('deliveries.award')
+			->where('year', '=', $arguments['year'])
+			->where('hidden', '=', 0)
+			->order_by('programme_title_1')->get();
+		foreach ($programmes as $programme) {
+			$deliveries = $programme->deliveries;
+			$default_delivery = $programme->getDefaultDelivery($deliveries);
+			$preferred_delivery = null;
+			$preferred_delivery = $programme->getPreferredDelivery($deliveries);
+			echo $programme->programme_title_1 . "\n";
+			foreach ($deliveries as $delivery) {
+				$is_default = ($default_delivery && $delivery->id == $default_delivery->id) ? '* ' : '';
+				$is_preferred = ($preferred_delivery && $delivery->id == $preferred_delivery->id) ? '+' : '';
+				echo "$is_preferred\t$is_default$delivery->description\n";
+			}
+		}
+	}
+
+	private function parseArguments($arguments = array())
+	{
+		$parsedArguments = array();
+
+		foreach ($arguments as $argument) {
+			$argumentPair = explode('=', $argument);
+			if (count($argumentPair) == 2) {
+				$parsedArguments[$argumentPair[0]] = $argumentPair[1];
+			}
+			else{
+				$parsedArguments[$argument] = $argument;
+			}
+		}
+
+		if (!isset($parsedArguments['year'])) {
+			self::printUsage();
+		}
+
+		if (!is_numeric($parsedArguments['year']) || strlen($parsedArguments['year']) !== 4) {
+			self::printUsage();
+		}
+		return $parsedArguments;
+	}
+
+	/**
+	 * Sets the default award and attendance pattern. Default options will only set defaults if no default is already set.
+	 * php artisan default-delivery:set year=<year> [filter=<filter-text>] [ids=<comma,separated,programme,ids] [--force] [--dry-run] [--clear-mcr]
+	 * @param array $arguments - key => value arguments
+	 * - year is required
+	 * - -d - just outputs the result without doing anything
+	 * - -f - overwrite existing values
+	 * - -c - clear the mcr value if it is set.
+	 */
+	public function set($arguments = array())
+	{
+		$mcr_field = PG_Programme::get_display_course_structure_mcr_field();
+		$award_field = PG_Programme::get_display_course_structure_award_field();
+		$pattern_field = PG_Programme::get_display_course_structure_attendance_pattern_field();
+
+		$arguments = $this->parseArguments($arguments);
+		$force = isset($arguments['-f']);
+		$dry = isset($arguments['-d']);
+		$clear_mcr = isset($arguments['-c']);
+		$ids = array();
+		foreach(isset($arguments['ids']) ? explode(',',$arguments['ids']) : array() as $id) {
+			settype($id,'integer');
+			if($id) {
+				$ids[] = $id;
+			}
+		}
+		$filter = !empty($arguments['filter']) ? $arguments['filter'] : '';
+		$programmes = PG_Programme::with('deliveries.award')
+			->where('year', '=', $arguments['year'])
+			->where('hidden', '=', 0)
+			->order_by('programme_title_1');
+		if($ids) {
+			$programmes = $programmes->where_in('instance_id',$ids);
+		}
+		if($filter) {
+			$programmes->where('programme_title_1','like',"%$filter%");
+		}
+		$programmes = $programmes->get();
+		foreach ($programmes as $programme) {
+			$deliveries = $programme->deliveries;
+			$default_delivery = $programme->getDefaultDelivery($deliveries);
+			$preferred_delivery = $programme->getPreferredDelivery($deliveries);
+			if(!$preferred_delivery || $force) {
+				$programme->$award_field = $default_delivery && $default_delivery->relatedaward ? $default_delivery->relatedaward->name : '';
+				$programme->$pattern_field = $default_delivery ? $default_delivery->attendance_pattern : '';
+			}
+			if($clear_mcr) {
+				$programme->$mcr_field = '';
+			}
+			if(!$dry) {
+				$this->savePreferredDelivery($programme);
+			}
+			echo $programme->programme_title_1 . "\n";
+			foreach ($deliveries as $delivery) {
+				$is_default = ($default_delivery && $delivery->id == $default_delivery->id) ? '* ' : '';
+				$is_preferred = ($preferred_delivery && $delivery->id == $preferred_delivery->id) ? '+' : '';
+				echo "$is_preferred\t$is_default$delivery->description\n";
+			}
+		}
+	}
+
+	/**
+	 * Updates the programmes_pg and programmes_revisions_pg tables with the specified preferred delivery info for
+	 * a program.
+	 * We update all revisions of the programme in the year we are updating to avoid dealing with whether or not the
+	 * program / current revision is published etc as this is a (more-or-less) one-off task.
+	 * Finally we need to clear the cache for this programme...
+	 * ... oh wait do we need to regenerate a cache afterwards?
+	 * @param $programme
+	 */
+	private function savePreferredDelivery(PG_Programme $programme)
+	{
+		// get field names
+		$mcr_field = PG_Programme::get_display_course_structure_mcr_field();
+		$award_field = PG_Programme::get_display_course_structure_award_field();
+		$pattern_field = PG_Programme::get_display_course_structure_attendance_pattern_field();
+		$updates = array(
+			$mcr_field => $programme->$mcr_field,
+			$award_field => $programme->$award_field,
+			$pattern_field => $programme->$pattern_field
+		);
+		DB::table(PG_Programme::$table)
+			->where('id', '=', $programme->id)
+			->update($updates);
+		$revision_model = PG_Programme::$revision_model;
+		DB::table($revision_model::$table)
+			->where('programme_id','=',$programme->id)
+			->update($updates);
+	}
+
+	private function printUsage()
+	{
+		echo 'usage:
+
+// to see the current default delivery and preferred delivery for all courses for a particular year
+php artisan default-delivery year=<year>
+
+// to set the defaults use:
+php artisan default-delivery:set year=<year> [filter=<filter-text>] [ids=<comma,separated,programme,ids] [--force] [--dry-run] [--clear-mcr]
+- year is required
+- filter=<filter-text> - only affect programmes whose title matches the filter
+- ids=<programme_ids> - only affect programmes whose ids are in the comma separated list.
+- --dry-run - just outputs the result without doing anything
+- --force - overwrite existing values
+- --clear-mcr - clear the mcr value if it is set.
+';
+		die();
+	}
+
+	public function help()
+	{
+		$this->printUsage();
+	}
+}

--- a/paths.php
+++ b/paths.php
@@ -22,7 +22,7 @@
 */
 
 $environments = array(
-	'local' => array('http://localhost*', '*.dev', '*.local', '*.local:9000', '192.168*', '*.vg', '*.test'),
+	'local' => array('http://localhost*', '*.dev', '*.local', '*.local:9000', '192.168*', '*.vg', '*plant.test'),
 	'test' => array('')
 );
 


### PR DESCRIPTION
This adds some information about the delivery to each set of module clusters. 

This is to enable of-course to choose which modules to display based on the delivery they belong to. Previously the modules did not contain any identifying information about the delivery they were for. 

ALSO

This fixes an issue where it was possible to trigger an exception when replacing ids with values. I kept triggering this locally when my cached data was out of sync with the fields in programmes plant. (in my case after adding custom fields and then reverting to a previous database dump)

I don't believe this change does anything other than be more careful but it can be omitted if required. 