### PR TITLE
Override delete() in Image to soft-delete the actual image files.

### DIFF
--- a/application/models/image.php
+++ b/application/models/image.php
@@ -42,13 +42,23 @@ class Image extends SimpleData
 
 	/**
 	 * File path to image
+	 * @param bool $hidden - Do we want path for hidden version of this image?
+	 * @return string Path for this image (whether or not a file actually exists)
 	 */
-	public function path(){
+	public function path($hidden = false){
 		$path = Config::get('images.image_directory', path('storage').'images');
-		return  $path.'/'.$new->id.'.jpg';
+		return  $path.'/'.($hidden ? '.' : '') . $this->id.'.jpg';
 	}
 
-
+	/**
+	 * File path to thumbnail
+	 * @param bool $hidden - Do we want path for hidden version of this image?
+	 * @return string Path for this image (whether or not a file actually exists)
+	 */
+	public function thumb_path($hidden = false){
+		$path = Config::get('images.image_directory', path('storage').'images');
+		return  $path.'/'.($hidden ? '.' : '') . $this->id.'_thumb.jpg';
+	}
 	/**
 	 * generate API data
 	 * Get live version of API data from database
@@ -117,5 +127,22 @@ class Image extends SimpleData
 		}	
 
 		return array($desired_height, $desired_width);
+	}
+
+	/**
+	 * When an image is deleted (actually just hidden) we need to also hide the actual
+	 * image files so that they are not accessible when their URL is known (eg google search)
+	 */
+	public function delete()
+	{
+		parent::delete();
+		$visible_path = $this->path(false);
+		if (file_exists($visible_path)) {
+			rename($visible_path, $this->path(true));
+		}
+		$thumb_path = $this->thumb_path(false);
+		if (file_exists($thumb_path)) {
+			rename($thumb_path, $this->thumb_path(true));
+		}
 	}
 }


### PR DESCRIPTION
When an image was deleted only the database record was set to hidden - the actual files were
left where they were.

This meant that if the URLs were known (e.g. google cache / image search) then the images could still
be displayed.

This fix prefixes the image and thumbnail filenames with a '.' when images are deleted, so that the old URLs no longer work.

We could actually delete the image files, but as "deleting" only hides the database records it makes
more sense to hide the files so we can retrieve them if need be.

To test, 
* add an image to programmes plant
* view the image url and thumb url directly
* delete the image
* confirm that the image is no longer available at the image and thumb url
* confirm that the image actually is available if you prefix the image and thumbnail filenames with a '.'.