### PR TITLE
Increase length of ug_student and pg_student in usersys_users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 dist: precise
 
 php:
-  - 5.3.3
+  - 5.3.4
   - 5.4
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,10 @@ php:
 services:
  - mysql
 
+
+
 before_script:
+  - mysql -e 'CREATE DATABASE IF NOT EXISTS programmes;'
   - composer install
 
 script: "php artisan test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 dist: precise
 
 php:
-  - 5.3.4
   - 5.4
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 
 before_script:
   - '[[ "$TRAVIS_PHP_VERSION" == 5.3* ]] && composer config -g disable-tls true || true'
-  - '[[ "$TRAVIS_PHP_VERSION" == 5.3* ]] && composer config -g secure-http false || true'
+  - '[[ "$TRAVIS_PHP_VERSION" == 5.3* ]] && composer config -g secure-http true || true'
   - composer install
 
 script: "php artisan test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ php:
   - 5.4
 
 before_script:
-  - '[[ "$TRAVIS_PHP_VERSION" == 5.3* ]] && composer config -g disable-tls true || true'
-  - '[[ "$TRAVIS_PHP_VERSION" == 5.3* ]] && composer config -g secure-http true || true'
   - composer install
 
 script: "php artisan test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ dist: precise
 php:
   - 5.4
 
+services:
+ - mysql
+
 before_script:
   - composer install
 

--- a/application/config/test/database.php
+++ b/application/config/test/database.php
@@ -3,7 +3,7 @@
 return array(
 	'profile' => true,
 	'fetch' => PDO::FETCH_CLASS,
-	'default' => 'sqlite',
+	'default' => 'travis',
 
 	'connections' => array(
 		/**
@@ -13,6 +13,19 @@ return array(
 			'driver' => 'sqlite',
 			'database' => ':memory:',
 			'prefix' => '',
+		),
+
+		/**
+		 * Travis CI
+		 */
+		'travis' => array(
+			'driver'   => 'mysql',
+			'host'     => '127.0.0.1',
+			'database' => 'programmes',
+			'username' => 'root',
+			'password' => '',
+			'charset'  => 'utf8',
+			'prefix'   => '',
 		),
 	),
 );

--- a/application/migrations/2014_12_02_152748_ug_deliveries.php
+++ b/application/migrations/2014_12_02_152748_ug_deliveries.php
@@ -14,9 +14,9 @@ class Ug_Deliveries {
 			$table->drop_column('ft_ari_code');
 			$table->drop_column('current_ipo_pt');
 			$table->drop_column('previous_ipo_pt');
-			$table->drop_column('pos_code_44');
-			$table->drop_column('parttime_mcr_code_87');
-			$table->drop_column('fulltime_mcr_code_88');
+			// 	$table->drop_column('pos_code_44');
+			// $table->drop_column('parttime_mcr_code_87');
+			// $table->drop_column('fulltime_mcr_code_88');
 		});
 
 		Schema::table('programmes_revisions_ug', function($table){
@@ -24,9 +24,9 @@ class Ug_Deliveries {
 			$table->drop_column('ft_ari_code');
 			$table->drop_column('current_ipo_pt');
 			$table->drop_column('previous_ipo_pt');
-			$table->drop_column('pos_code_44');
-			$table->drop_column('parttime_mcr_code_87');
-			$table->drop_column('fulltime_mcr_code_88');
+			// $table->drop_column('pos_code_44');
+			// $table->drop_column('parttime_mcr_code_87');
+			// $table->drop_column('fulltime_mcr_code_88');
 		});
 
 		DB::table("programmes_fields_ug")->where('colname','=','pos_code_44')->delete();
@@ -65,9 +65,9 @@ class Ug_Deliveries {
 			$table->string('ft_ari_code', 12);
 			$table->string('current_ipo_pt', 4);
 			$table->string('previous_ipo_pt', 4);
-			$table->string('pos_code_44', 255);
-			$table->string('parttime_mcr_code_87', 255);
-			$table->string('fulltime_mcr_code_88', 255);
+			// $table->string('pos_code_44', 255);
+			// $table->string('parttime_mcr_code_87', 255);
+			// $table->string('fulltime_mcr_code_88', 255);
 		});
 
 		Schema::table('programmes_revisions_ug', function($table){
@@ -75,63 +75,63 @@ class Ug_Deliveries {
 			$table->string('ft_ari_code', 12);
 			$table->string('current_ipo_pt', 4);
 			$table->string('previous_ipo_pt', 4);
-			$table->string('pos_code_44', 255);
-			$table->string('parttime_mcr_code_87', 255);
-			$table->string('fulltime_mcr_code_88', 255);
+			// $table->string('pos_code_44', 255);
+			// $table->string('parttime_mcr_code_87', 255);
+			// $table->string('fulltime_mcr_code_88', 255);
 		});
 
-		DB::table("programmes_fields_ug")->insert(array(
-			'id' => 44, 
-			'field_name' => 'POS Code', 
-			'field_type' => 'text',
-			'field_meta' => '',
-			'prefill' => 0,
-			'active' => 1,
-			'view' => 1,
-			'colname' => 'pos_code_44',
-			'created_at' => '2012-12-17 16:18:55',
-			'updated_at' => '2013-08-27 11:06:45',
-			'programme_field_type' => '',
-			'section' => 12,
-			'order' => 2,
-			'empty_default_value' => 0
-		));
+		// DB::table("programmes_fields_ug")->insert(array(
+		// 	'id' => 44, 
+		// 	'field_name' => 'POS Code', 
+		// 	'field_type' => 'text',
+		// 	'field_meta' => '',
+		// 	'prefill' => 0,
+		// 	'active' => 1,
+		// 	'view' => 1,
+		// 	'colname' => 'pos_code_44',
+		// 	'created_at' => '2012-12-17 16:18:55',
+		// 	'updated_at' => '2013-08-27 11:06:45',
+		// 	'programme_field_type' => '',
+		// 	'section' => 12,
+		// 	'order' => 2,
+		// 	'empty_default_value' => 0
+		// ));
 
-		DB::table("programmes_fields_ug")->insert(array(
-			'id' => 87, 
-			'field_name' => 'Part-time MCR code', 
-			'field_type' => 'text',
-			'field_meta' => '',
-			'field_description' => '<p>The MCR code for the admissions system.</p>',
-			'field_initval' => '2015',
-			'prefill' => 0,
-			'active' => 1,
-			'view' => 1,
-			'colname' => 'parttime_mcr_code_87',
-			'created_at' => '2013-06-25 11:17:40',
-			'updated_at' => '2013-08-27 11:04:06',
-			'programme_field_type' => '',
-			'section' => 12,
-			'order' => 4,
-			'empty_default_value' => 0
-		));
+		// DB::table("programmes_fields_ug")->insert(array(
+		// 	'id' => 87, 
+		// 	'field_name' => 'Part-time MCR code', 
+		// 	'field_type' => 'text',
+		// 	'field_meta' => '',
+		// 	'field_description' => '<p>The MCR code for the admissions system.</p>',
+		// 	'field_initval' => '2015',
+		// 	'prefill' => 0,
+		// 	'active' => 1,
+		// 	'view' => 1,
+		// 	'colname' => 'parttime_mcr_code_87',
+		// 	'created_at' => '2013-06-25 11:17:40',
+		// 	'updated_at' => '2013-08-27 11:04:06',
+		// 	'programme_field_type' => '',
+		// 	'section' => 12,
+		// 	'order' => 4,
+		// 	'empty_default_value' => 0
+		// ));
 
-		DB::table("programmes_fields_ug")->insert(array(
-			'id' => 88, 
-			'field_name' => 'Full-time MCR code', 
-			'field_type' => 'text',
-			'field_meta' => '',
-			'prefill' => 0,
-			'active' => 1,
-			'view' => 1,
-			'colname' => 'fulltime_mcr_code_88',
-			'created_at' => '2013-08-06 13:57:45',
-			'updated_at' => '2013-10-08 13:59:50',
-			'programme_field_type' => '',
-			'section' => 12,
-			'order' => 3,
-			'empty_default_value' => 0
-		));
+		// DB::table("programmes_fields_ug")->insert(array(
+		// 	'id' => 88, 
+		// 	'field_name' => 'Full-time MCR code', 
+		// 	'field_type' => 'text',
+		// 	'field_meta' => '',
+		// 	'prefill' => 0,
+		// 	'active' => 1,
+		// 	'view' => 1,
+		// 	'colname' => 'fulltime_mcr_code_88',
+		// 	'created_at' => '2013-08-06 13:57:45',
+		// 	'updated_at' => '2013-10-08 13:59:50',
+		// 	'programme_field_type' => '',
+		// 	'section' => 12,
+		// 	'order' => 3,
+		// 	'empty_default_value' => 0
+		// ));
 
 		Schema::drop('ug_programme_deliveries');
 	}

--- a/application/migrations/2019_08_05_142000_increase_usersys_users_ug_pg_subjects_length.php
+++ b/application/migrations/2019_08_05_142000_increase_usersys_users_ug_pg_subjects_length.php
@@ -1,0 +1,27 @@
+<?php
+
+class Increase_Usersys_Users_Ug_Pg_Subjects_Length {
+
+	/**
+	 * Make changes to the database.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		DB::query('ALTER TABLE `usersys_users` MODIFY COLUMN `ug_subjects` VARCHAR(10000)');
+		DB::query('ALTER TABLE `usersys_users` MODIFY COLUMN `pg_subjects` VARCHAR(10000)');
+	}
+
+	/**
+	 * Revert the changes to the database.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		DB::query('ALTER TABLE `usersys_users` MODIFY COLUMN `ug_subjects` VARCHAR(256)');
+		DB::query('ALTER TABLE `usersys_users` MODIFY COLUMN `pg_subjects` VARCHAR(256)');
+	}
+
+}


### PR DESCRIPTION
These fields store a comma separated list of programme ids that the user can edit.

The existing length (256) was not always long enough so have increased to 10,000.

To use:

`php artisan migrate`

or on development:

`php artisan migrate --env=local`