### PR TITLE
Fix/enlarge ug pg subjects column

### DIFF
--- a/application/migrations/2019_08_05_142000_increase_usersys_users_ug_pg_subjects_length.php
+++ b/application/migrations/2019_08_05_142000_increase_usersys_users_ug_pg_subjects_length.php
@@ -9,8 +9,11 @@ class Increase_Usersys_Users_Ug_Pg_Subjects_Length {
 	 */
 	public function up()
 	{
-		DB::query('ALTER TABLE `usersys_users` MODIFY COLUMN `ug_subjects` VARCHAR(10000)');
-		DB::query('ALTER TABLE `usersys_users` MODIFY COLUMN `pg_subjects` VARCHAR(10000)');
+		// sqlite (used for testing) does not support modifying columns
+		if(DB::connection()->config['driver'] !== 'sqlite') {
+			DB::query('ALTER TABLE `usersys_users` MODIFY COLUMN `ug_subjects` VARCHAR(10000)');
+			DB::query('ALTER TABLE `usersys_users` MODIFY COLUMN `pg_subjects` VARCHAR(10000)');
+		}
 	}
 
 	/**
@@ -20,8 +23,10 @@ class Increase_Usersys_Users_Ug_Pg_Subjects_Length {
 	 */
 	public function down()
 	{
-		DB::query('ALTER TABLE `usersys_users` MODIFY COLUMN `ug_subjects` VARCHAR(256)');
-		DB::query('ALTER TABLE `usersys_users` MODIFY COLUMN `pg_subjects` VARCHAR(256)');
+		if(DB::connection()->config['driver'] !== 'sqlite') {
+			DB::query('ALTER TABLE `usersys_users` MODIFY COLUMN `ug_subjects` VARCHAR(256)');
+			DB::query('ALTER TABLE `usersys_users` MODIFY COLUMN `pg_subjects` VARCHAR(256)');
+		}
 	}
 
 }

--- a/application/migrations/2019_08_05_142000_increase_usersys_users_ug_pg_subjects_length.php
+++ b/application/migrations/2019_08_05_142000_increase_usersys_users_ug_pg_subjects_length.php
@@ -1,0 +1,27 @@
+<?php
+
+class Increase_Usersys_Users_Ug_Pg_Subjects_Length {
+
+	/**
+	 * Make changes to the database.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		DB::query('ALTER TABLE `usersys_users` MODIFY COLUMN `ug_subjects` VARCHAR(10000)');
+		DB::query('ALTER TABLE `usersys_users` MODIFY COLUMN `pg_subjects` VARCHAR(10000)');
+	}
+
+	/**
+	 * Revert the changes to the database.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		DB::query('ALTER TABLE `usersys_users` MODIFY COLUMN `ug_subjects` VARCHAR(256)');
+		DB::query('ALTER TABLE `usersys_users` MODIFY COLUMN `pg_subjects` VARCHAR(256)');
+	}
+
+}


### PR DESCRIPTION
The ug_subjects and pg_subjects columns in the usersys_users table are used to hold a comma separated list of subjects that a user can edit things for.

They were not long enough to hold all of them.

Now they are longer.

SQLITE (which is used for unit tests) appears not to support modifying columns, so added a check to skip the migration if sqlite is detected.