### PR TITLE
Adds a file upload field type for use with programmes

### DIFF
--- a/application/config/images.php.sample
+++ b/application/config/images.php.sample
@@ -1,5 +1,8 @@
 <?php
 return array(
 	'image_directory' => '',
-	'image_public_url' => ''
+	'image_public_url' => '',
+	'upload_directory' => dirname(__FILE__)  . '/../../../storage/uploads',
+	'upload_public_url' => '/uploads',
+	'upload_dir_mode' => 0754,
 );

--- a/application/controllers/programmes.php
+++ b/application/controllers/programmes.php
@@ -212,10 +212,14 @@ class Programmes_Controller extends Revisionable_Controller {
 		$fieldModel = $this->model.'Field';
 		$model = $this->model;
 
-		// placeholder for any future validation rules
-		$rules = array(
+		// get the programme fields
+		$programme_fields = $fieldModel::programme_fields();
 
-		);
+		$input = Input::all();
+
+		// placeholder for any future validation rules
+		$rules = $this->getValidationRules($programme_fields, $input);
+
 		$messages = array();
 		if ($model === 'PG_Programme') {
 			//Get mode_of_study, duration and parttime_duration fields
@@ -247,9 +251,6 @@ class Programmes_Controller extends Revisionable_Controller {
 		
 			$programme->year = Input::get('year');
 			
-			// get the programme fields
-			$programme_fields = $fieldModel::programme_fields();
-		
 			// assign the input data to the programme fields
 			$programme_modified = $fieldModel::assign_fields($programme, $programme_fields, Input::all());
 
@@ -263,6 +264,24 @@ class Programmes_Controller extends Revisionable_Controller {
 			// redirect back to the same page we were on
 			return Redirect::to($year.'/'. $type.'/'. $this->views.'/edit/'.$programme->instance_id);
 		}
+	}
+
+	/**
+	 * Gets validation rules for defined fields
+	 * @param $fields
+	 * @param $input
+	 * @return array
+	 */
+	public function getValidationRules($fields, $input)
+	{
+		// currently only adds validation for 'file' fields
+		$rules = array();
+		foreach($fields as $field) {
+			if('file' === $field->field_type) {
+				$rules[$field->colname . '_upload'] = 'mimes:pdf,doc,docx';
+			}
+		}
+		return $rules;
 	}
 
 	/**

--- a/application/controllers/programmes.php
+++ b/application/controllers/programmes.php
@@ -166,9 +166,14 @@ class Programmes_Controller extends Revisionable_Controller {
 
 		$this->check_user_can("create_programmes");
 
+		// get the programme fields
+		$programme_fields = $fieldModel::programme_fields();
+
+		$input = Input::all();
+
 		// placeholder for any future validation rules
-		$rules = array(
-		);
+		$rules = $this->getValidationRules($programme_fields, $input);
+
 		$validation = Validator::make(Input::all(), $rules);
 		if ($validation->fails()) 
 		{
@@ -180,10 +185,7 @@ class Programmes_Controller extends Revisionable_Controller {
 			$programme = new $model;
 			$programme->year = Input::get('year');
 			$programme->created_by = Auth::user()->username;
-			
-			// get the programme fields
-			$programme_fields = $fieldModel::programme_fields();
-			
+
 			// assign the input data to the programme fields
 			$programme_modified = $fieldModel::assign_fields($programme, $programme_fields, Input::all());
 			

--- a/application/libraries/Kent/Form.php
+++ b/application/libraries/Kent/Form.php
@@ -362,4 +362,20 @@ class Form extends \Laravel\Form {
 		}
 		return '<div class="img-picker"><textarea class="picker" rows="1" name="' . $name . '">' . $value .'</textarea><div class="img-wrapper">' . $imgTag . '</div><strong class="img-name">' . ($image? $image->name: '<em>Unassigned</em>') . '</strong></div>';
 	}
+
+	public static function fileUploader($name, $value = null)
+	{
+		$output = '<input type="hidden" name="' . $name . '" value="' . htmlspecialchars($value) . '" />';
+		if($value) {
+			$url = \Config::get('images.upload_public_url', url('/uploads')) . '/' . $value;
+			$output .= '<br /><a href="' . $url . '" target="_blank">' . preg_replace('/^.*\//', '', $value) . '</a>';
+			// option to remove the link to the specification
+			$output .= '<br /><br /><label><input type="checkbox" name="' . $name . '_clear" value="1" /> Remove link</label>';
+		}
+		else {
+			$output .= '<br /><strong class="img-name"><em>Unassigned</em></strong>';
+		}
+		$output .= '<br /><input type="file" name="' . $name . '_upload" />';
+		return $output;
+	}
 }

--- a/application/models/field.php
+++ b/application/models/field.php
@@ -21,7 +21,7 @@ class Field extends Eloquent
 	 */
 	public static $rules = array(
 		'title'  => 'required|max:255',
-		'type' => 'in:text,textarea,select,checkbox,help,table_select,table_multiselect,image'
+		'type' => 'in:text,textarea,select,checkbox,help,table_select,table_multiselect,image,file'
 	);
 
 	/**

--- a/application/models/programmefield.php
+++ b/application/models/programmefield.php
@@ -122,7 +122,8 @@ abstract class ProgrammeField extends Field
     public static function process_file_input_field($programme, $programme_field, $upload)
     {
     	if(is_uploaded_file($upload['tmp_name'])) {
-    		$relative_path = 'programmes/' . $programme->id . '/' . static::niceifyFilename($programme_field->field_name);
+    		$id = $programme->id ? $programme->id : 'new';
+    		$relative_path = 'programmes/' . $id . '/' . static::niceifyFilename($programme_field->field_name);
     		$upload_path = Config::get('images.upload_directory', path('storage').'/uploads') . '/' . $relative_path;
     		$filename = static::niceifyFilename(date('YmdHis') . '_' . $upload['name']);
 			if(!file_exists($upload_path)) {

--- a/application/views/admin/fields/form.php
+++ b/application/views/admin/fields/form.php
@@ -20,7 +20,7 @@
   <div class="control-group">
     <?php echo Form::label('type', __('fields.form.label_type'), array('class'=>'control-label'))?>
     <div class="controls">
-      <?php echo Form::select('type', array('text'=>'text','textarea'=>'textarea', 'select'=>'select', 'checkbox'=>'checkbox', 'table_select'=>'select from model', 'table_multiselect'=>'multiselect from model', 'image'=> 'Image', 'help'=>'Help text section'), (isset($values)) ? $values->field_type : '', array('onchange'=>'show_options(this);') )?>
+      <?php echo Form::select('type', array('text'=>'text','textarea'=>'textarea', 'select'=>'select', 'checkbox'=>'checkbox', 'table_select'=>'select from model', 'table_multiselect'=>'multiselect from model', 'image'=> 'Image', 'help'=>'Help text section', 'file' => 'File'), (isset($values)) ? $values->field_type : '', array('onchange'=>'show_options(this);') )?>
     </div>
   </div>
 

--- a/application/views/admin/inc/partials/formfields.php
+++ b/application/views/admin/inc/partials/formfields.php
@@ -86,6 +86,9 @@ foreach($section as $field):
 		  $form_element = Form::imagePicker($column_name, $current_value);
 	  break;
 
+          case 'file':
+          	$form_element = Form::fileUploader($column_name, $current_value);
+          	break;
       case 'table_multiselect':
         $model = $field->field_meta;
         $form_element = ExtForm::multiselect($column_name.'[]', $model::all_as_list($year), explode(',',$current_value), array('style'=>'height:200px;width:600px;'));
@@ -121,6 +124,12 @@ foreach($section as $field):
 				<br><br>
 			<p class="alert alert-danger"><?php echo $errors->first($column_name); ?></p>
 			<?php
+			} ?>
+			<?php if ($errors->has($column_name . '_upload')){
+				?>
+                <br><br>
+                <p class="alert alert-danger"><?php echo $errors->first($column_name.'_upload'); ?></p>
+				<?php
 			} ?>
 			<?php if(isset($field->programme_field_type) && $field->programme_field_type == $field_model::$types['OVERRIDABLE_DEFAULT']): ?>
 


### PR DESCRIPTION
Add a file field type that can be added as fields to ug and pg programmes.

 - Allows a single file to be uploaded to the field
 - Files can be pdf, doc or docx
 - File is stored under an uploads directory and is named roughly /{programme-id}/{field-name}/{timestamp}-filename
 - Uploads directory, public url and directory creation permissions mode is configured inside config/images.php
 - Users can remove the link to an uploaded file by ticking a checkbox instead of uploading a new file.

### Testing

1. Pull down this branch
1. To publicly view files perhaps create a symlink in public from 'uploads' to '../storage/uploads' 
1. Configure config/images.php (or config/local/images.php)? with paths based on this.
1. Add a new ug programme field of type 'file' (maybe "Programme Specification")?
1. Edit an existing programme and see if you can upload a file.
1. Won't work properly yet on creating a programme...
