### PR TITLE
Add image urls to programmes api output

### DIFF
--- a/application/models/programme.php
+++ b/application/models/programme.php
@@ -434,8 +434,8 @@ abstract class Programme extends Revisionable {
 			$programme_type_field,
 			$withdrawn_field,
 			$suspended_field,
-			$science_without_borders_field
-
+			$science_without_borders_field,
+			static::get_banner_image_field(),
 		);
 		// If UG, add ucas field
 		if ($type == 'ug') {

--- a/application/models/programme.php
+++ b/application/models/programme.php
@@ -463,7 +463,7 @@ abstract class Programme extends Revisionable {
 		}
 
 		// Pull out all revisions that have there id within the above array (as these are what need to be published)
-		$programmes = $revision_model::with(array('award', 'subject_area_1', 'administrative_school', 'additional_school', 'location'))
+		$programmes = $revision_model::with(array('award', 'subject_area_1', 'administrative_school', 'additional_school', 'location', 'banner_image'))
 			->where_in('id', $live_revisions_ids)
 			->get($fields);
 
@@ -514,7 +514,8 @@ abstract class Programme extends Revisionable {
 				'programme_type' => isset($attributes[$programme_type_field]) ? $attributes[$programme_type_field] : '',
 				'study_abroad_option' => isset($attributes[$study_abroad_option_field]) ? $attributes[$study_abroad_option_field] : '',
 				'science_without_borders' => isset($attributes[$science_without_borders_field]) ? $attributes[$science_without_borders_field] : '',
-				'attendance_mode' => isset($attributes[$attendance_mode_field]) ? $attributes[$attendance_mode_field] : ''
+				'attendance_mode' => isset($attributes[$attendance_mode_field]) ? $attributes[$attendance_mode_field] : '',
+				'banner_image' => $programme->banner_image ? $programme->banner_image->to_array() : array(),
 			);
 
 			$statuses = '(';

--- a/application/models/programmerevision.php
+++ b/application/models/programmerevision.php
@@ -32,6 +32,12 @@ abstract class ProgrammeRevision extends Revision
         return $this->belongs_to('School', $model::get_additional_school_field());
     }
 
+	public function banner_image()
+	{
+		$model = static::$programme_model;
+		return $this->belongs_to('Image', $model::get_banner_image_field());
+	}
+
     /**
      * Get this programme's campus.
      * 


### PR DESCRIPTION
NOTE
 - image urls are based on the images.image_public_url config value (so will be full or relative depending on what that value is)

- if testing locally everything gets cached, so you may find:  rm -rf storage/cache/* (or equivalent for your environment) is required.
