### PR TITLE
Artisan task to resize thumbnails proportionally to fit within max width value

### DIFF
--- a/application/config/images.php.sample
+++ b/application/config/images.php.sample
@@ -2,6 +2,7 @@
 return array(
 	'image_directory' => '',
 	'image_public_url' => '',
+	'thumbnail_max_width' => 320,
 	'upload_directory' => dirname(__FILE__)  . '/../../../storage/uploads',
 	'upload_public_url' => '/uploads',
 	'upload_dir_mode' => 0754,

--- a/application/controllers/images.php
+++ b/application/controllers/images.php
@@ -122,7 +122,7 @@ class Images_Controller extends Simple_Admin_Controller {
 		$u = Input::upload('image', $path, $img_id.'.jpg');
 
 		if($u){
-			$this->make_thumb( $path.'/'.$img_id.'.jpg', $path.'/'.$img_id.'_thumb.jpg', 160);
+			$this->make_thumb( $path.'/'.$img_id.'.jpg', $path.'/'.$img_id.'_thumb.jpg', Config::get('images.thumbnail_max_width', 160));
 		}
 
 		return $u;

--- a/application/models/image.php
+++ b/application/models/image.php
@@ -98,7 +98,7 @@ class Image extends SimpleData
 		);
 
 		//die($data['width'], $data['height']);
-		list($thumb_height, $thumb_width) = static::getThumbSize(170, $data['width'], $data['height']);
+		list($thumb_height, $thumb_width) = static::getThumbSize(Config::get('images.thumbnail_max_width', 160), $data['width'], $data['height']);
 
 		$data['sizes'] = array(
 			'full' => array('url' => $this->url(), 'width'=> (int) $data['width'], 'height'=> (int)$data['height']),

--- a/application/tasks/resizethumbnails.php
+++ b/application/tasks/resizethumbnails.php
@@ -8,19 +8,22 @@ class ResizeThumbnails_Task {
 	/**
 	 * Run the setinitaluser task
 	 *
-	 * @param array  $arguments The arguments sent to the seed command.
+	 * @param array  $arguments The arguments sent to the command. Optional maxWidth
 	 */
 	public function run($arguments = array())
 	{
 		// Dont run if no username provided
 		if(sizeof($arguments) === 0){
-			echo "\n Error: Please specify the desired maximum width. \n";
-			return;
+			$maxWidth = Config::get('images.thumbnail_max_width');
 		}
-		$maxWidth = (int)$arguments[0];
+		else {
+			$maxWidth = (int)$arguments[0];
+		}
 		if($maxWidth < 50) {
 			echo "\n Error: width cannot be less than 50. \n";
 		}
+		echo "Resizing images to maximum width of $maxWidth\n\n";
+		$images = Image::get();
 
 		foreach( Image::get() as $image) {
 			$path = Config::get('images.image_directory', path('storage').'images');
@@ -33,6 +36,7 @@ class ResizeThumbnails_Task {
 			else {
 				echo "FAILED\n";
 			}
+			flush();
 		}
 	}
 

--- a/application/tasks/resizethumbnails.php
+++ b/application/tasks/resizethumbnails.php
@@ -3,7 +3,8 @@
  *
  *
  */
-class ResizeThumbnails_Task {
+class ResizeThumbnails_Task
+{
 
 	/**
 	 * Run the setinitaluser task
@@ -12,34 +13,34 @@ class ResizeThumbnails_Task {
 	 */
 	public function run($arguments = array())
 	{
-		if(sizeof($arguments) === 0){
+		if (sizeof($arguments) === 0) {
 			$maxWidth =(int)Config::get('images.thumbnail_max_width');
 		} else {
 			$maxWidth = (int)$arguments[0];
 		}
-		if($maxWidth < 50) {
+		if ($maxWidth < 50) {
 			echo "\n Error: width cannot be less than 50. \n";
-            die();
+			die();
 		}
 		echo "Resizing images to maximum width of $maxWidth\n\n";
 		$images = Image::get();
 
-		foreach( Image::get() as $image) {
+		foreach (Image::get() as $image) {
 			$path = Config::get('images.image_directory', path('storage').'images');
 			$src = $path . '/' . $image->id . '.jpg';
 			$dest = $path . '/' . $image->id . '_thumb.jpg';
 			echo "Resizing {$image->id} - {$image->name}...";
-			if( $this->make_thumb( $path.'/'.$image->id.'.jpg', $path.'/'.$image->id.'_thumb.jpg', $maxWidth) ) {
+			if ($this->make_thumb($path.'/'.$image->id.'.jpg', $path.'/'.$image->id.'_thumb.jpg', $maxWidth)) {
 				echo "SUCCESS!\n";
-			}
-			else {
+			} else {
 				echo "FAILED\n";
 			}
 			flush();
 		}
 	}
 
-	protected function make_thumb($src, $dest, $desired_width) {
+	protected function make_thumb($src, $dest, $desired_width)
+	{
 		$result = false;
 		/* read the source image */
 		$source_image = imagecreatefromjpeg($src);
@@ -49,12 +50,12 @@ class ResizeThumbnails_Task {
 		// Get thumb sizeing
 		list($desired_height, $desired_width) = Image::getThumbSize($desired_width, $width, $height);
 
-		if($source_image) {
+		if ($source_image) {
 			/* create a new, "virtual" image */
 			$virtual_image = imagecreatetruecolor($desired_width, $desired_height);
-			if($virtual_image) {
+			if ($virtual_image) {
 				/* copy source image at a resized size */
-				if( imagecopyresampled($virtual_image, $source_image, 0, 0, 0, 0, $desired_width, $desired_height, $width, $height)) {
+				if (imagecopyresampled($virtual_image, $source_image, 0, 0, 0, 0, $desired_width, $desired_height, $width, $height)) {
 					/* create the physical thumbnail image to its destination */
 					$result = imagejpeg($virtual_image, $dest);
 				}
@@ -65,4 +66,3 @@ class ResizeThumbnails_Task {
 		return $result;
 	}
 }
-

--- a/application/tasks/resizethumbnails.php
+++ b/application/tasks/resizethumbnails.php
@@ -12,15 +12,14 @@ class ResizeThumbnails_Task {
 	 */
 	public function run($arguments = array())
 	{
-		// Dont run if no username provided
 		if(sizeof($arguments) === 0){
-			$maxWidth = Config::get('images.thumbnail_max_width');
-		}
-		else {
+			$maxWidth =(int)Config::get('images.thumbnail_max_width');
+		} else {
 			$maxWidth = (int)$arguments[0];
 		}
 		if($maxWidth < 50) {
 			echo "\n Error: width cannot be less than 50. \n";
+            die();
 		}
 		echo "Resizing images to maximum width of $maxWidth\n\n";
 		$images = Image::get();

--- a/application/tasks/resizethumbnails.php
+++ b/application/tasks/resizethumbnails.php
@@ -7,7 +7,7 @@ class ResizeThumbnails_Task
 {
 
 	/**
-	 * Run the setinitaluser task
+	 * Regenerate the thumbnails from the original images
 	 *
 	 * @param array  $arguments The arguments sent to the command. Optional maxWidth
 	 */

--- a/application/tasks/resizethumbnails.php
+++ b/application/tasks/resizethumbnails.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ *
+ *
+ */
+class ResizeThumbnails_Task {
+
+	/**
+	 * Run the setinitaluser task
+	 *
+	 * @param array  $arguments The arguments sent to the seed command.
+	 */
+	public function run($arguments = array())
+	{
+		// Dont run if no username provided
+		if(sizeof($arguments) === 0){
+			echo "\n Error: Please specify the desired maximum width. \n";
+			return;
+		}
+		$maxWidth = (int)$arguments[0];
+		if($maxWidth < 50) {
+			echo "\n Error: width cannot be less than 50. \n";
+		}
+
+		foreach( Image::get() as $image) {
+			$path = Config::get('images.image_directory', path('storage').'images');
+			$src = $path . '/' . $image->id . '.jpg';
+			$dest = $path . '/' . $image->id . '_thumb.jpg';
+			echo "Resizing {$image->id} - {$image->name}...";
+			if( $this->make_thumb( $path.'/'.$image->id.'.jpg', $path.'/'.$image->id.'_thumb.jpg', $maxWidth) ) {
+				echo "SUCCESS!\n";
+			}
+			else {
+				echo "FAILED\n";
+			}
+		}
+	}
+
+	protected function make_thumb($src, $dest, $desired_width) {
+		$result = false;
+		/* read the source image */
+		$source_image = imagecreatefromjpeg($src);
+		$width = imagesx($source_image);
+		$height = imagesy($source_image);
+
+		// Get thumb sizeing
+		list($desired_height, $desired_width) = Image::getThumbSize($desired_width, $width, $height);
+
+		if($source_image) {
+			/* create a new, "virtual" image */
+			$virtual_image = imagecreatetruecolor($desired_width, $desired_height);
+			if($virtual_image) {
+				/* copy source image at a resized size */
+				if( imagecopyresampled($virtual_image, $source_image, 0, 0, 0, 0, $desired_width, $desired_height, $width, $height)) {
+					/* create the physical thumbnail image to its destination */
+					$result = imagejpeg($virtual_image, $dest);
+				}
+				imagedestroy($virtual_image);
+			}
+			imagedestroy($source_image);
+		}
+		return $result;
+	}
+}
+


### PR DESCRIPTION
`php artisan resizethumbnails  --env=local`

by default will use the NEW config settings in config/images.php (or config/local/images.php) for thumbnail_max_width.

You can override this by providing a max width, e.g.:

`php artisan resizethumbnails 320  --env=local`


NOTE that the artisan command will resize thumbnails for ALL images, both for programmes AND for profiles.