### PR TITLE
Replace KIS field with imported CRS_Code to fix Discovery Uni widget data

### DIFF
--- a/application/models/programme.php
+++ b/application/models/programme.php
@@ -469,6 +469,11 @@ abstract class Programme extends Revisionable {
 			$fields[] = $attendance_mode_field;
 		}
 
+		// fields can be added in production therefore it is possible that this code
+		// expects something not in the current database when making calls to  get_????_field.
+		// Filter out the blanks from $fields out to prevent a error when generating the list of $programmes
+		$fields = array_filter($fields);
+
 		// Find all programmes that have a live revision set (live_revision != 0)
 		$programmes_with_live_revisions = static::where('year','=', $year)->where('live_revision', '!=', 0)->where('hidden', '!=', 1)->get('live_revision');
 

--- a/application/models/programme.php
+++ b/application/models/programme.php
@@ -471,7 +471,7 @@ abstract class Programme extends Revisionable {
 
 		// fields can be added in production therefore it is possible that this code
 		// expects something not in the current database when making calls to  get_????_field.
-		// Filter out the blanks from $fields out to prevent a error when generating the list of $programmes
+		// Filter out the blanks from $fields out to prevent an error when generating the list of $programmes
 		$fields = array_filter($fields);
 
 		// Find all programmes that have a live revision set (live_revision != 0)

--- a/bundles/verify_ldap/libraries/ldapconnect.php
+++ b/bundles/verify_ldap/libraries/ldapconnect.php
@@ -39,7 +39,7 @@ class LDAPConnect
     public function __construct($address, $port = 389)
     {
         $this->ldap_server_address = $address;
-        // use connect string rather than depricated address and port params to work
+        // use connect string rather than deprecated address and port params to work
         // around issue with using non-default port
         $this->ldap_connection = ldap_connect("$address:$port");
     }

--- a/bundles/verify_ldap/libraries/ldapconnect.php
+++ b/bundles/verify_ldap/libraries/ldapconnect.php
@@ -39,7 +39,9 @@ class LDAPConnect
     public function __construct($address, $port = 389)
     {
         $this->ldap_server_address = $address;
-        $this->ldap_connection = ldap_connect($address, $port);
+        // use connect string rather than depricated address and port params to work
+        // around issue with using non-default port
+        $this->ldap_connection = ldap_connect("$address:$port");
     }
 
     /**


### PR DESCRIPTION
* updates the SITSImport task to import any crs code found in the xml for a given course and uses that as the KISCOURSEID, note this avoids updating courses which arew currently being edited and makes a new live revision if it does update the KISCOURSEID
* fixes an issue where the creation of the api index fails if the the programme fields if it fails to find expected programme fields in the database. (these are added at runtime and not via migration so there is the potential for drift)