### PR TITLE
Add crs to postgraduate deliveries

### DIFF
--- a/application/migrations/2022_06_21_134534_add_crs_field_to_deliveries.php
+++ b/application/migrations/2022_06_21_134534_add_crs_field_to_deliveries.php
@@ -1,0 +1,29 @@
+<?php
+
+class Add_Crs_Field_To_Deliveries {
+
+	/**
+	 * Make changes to the database.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{		
+		Schema::table('pg_programme_deliveries', function($table){
+			$table->string('crs', 255)->nullable();
+		});
+	}
+
+	/**
+	 * Revert the changes to the database.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{	
+		Schema::table('pg_programme_deliveries', function($table){
+			$table->dropColumn('crs');
+		});	
+	}
+
+}

--- a/application/tasks/sitsimport.php
+++ b/application/tasks/sitsimport.php
@@ -309,9 +309,13 @@ class SITSImport_Task
 		$delivery->ari_code = (string)$course->ari_code;
 		$delivery->description = (string)$course->description;
 		$delivery->attendance_pattern = strtolower($course->attendanceType);
-
 		$delivery->current_ipo = $this->extractCurrentIPO($course, $year);
 		$delivery->previous_ipo='';
+
+		// add CRS to PG deliveries
+		if ($level !== 'ug') {
+			$delivery->crs = (string)$course->crs;
+		}
 
 		$delivery->save();
 


### PR DESCRIPTION
- adds a crs col to the pg deliveries table
- imports the crs from the XML for the pg deliveries with in the sitsimport task

API automatically outputs the crs field within the deliveries part of the api output
for https://trello.com/c/iK7t06ZW/1398-add-crs-code-to-the-programmes-plant-api-output-for-pg-deliveries

